### PR TITLE
feat: add branch input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ author: "Lab Digital"
 
 # Define your inputs here.
 inputs:
+  branch:
+    description: "Git Branch to compare against"
+    default: "main"
+    required: false
   config:
     description: "Inline configuration"
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -34579,7 +34579,10 @@ async function run() {
     );
     for (const pkgConfig of inputs.config.packages) {
       core3.info(`Processing ${pkgConfig.name}`);
-      const commitHash = await client.getLatestVersion(pkgConfig.name, inputs.branch);
+      const commitHash = await client.getLatestVersion(
+        pkgConfig.name,
+        inputs.branch
+      );
       const hasChanges = commitHash ? await checkForChanges(pkgConfig, commitHash) : true;
       if (hasChanges) {
         core3.info(`Changes detected in ${pkgConfig.scope}`);
@@ -34594,6 +34597,7 @@ async function run() {
 }
 var readInputs = () => {
   return {
+    branch: core3.getInput("branch"),
     config: parseConfig(core3.getInput("config")),
     mccClientID: core3.getInput("mcc_client_id"),
     mccClientSecret: core3.getInput("mcc_client_secret"),

--- a/dist/index.js
+++ b/dist/index.js
@@ -34567,7 +34567,6 @@ var Client = class {
 async function run() {
   try {
     const inputs = readInputs();
-    const result = [];
     const client = new Client({
       clientID: inputs.mccClientID,
       clientSecret: inputs.mccClientSecret,
@@ -34577,18 +34576,23 @@ async function run() {
     core3.info(
       "Checking for changes: \n" + inputs.config.packages.map((pkg) => ` - ${pkg.name}`).join("\n")
     );
-    for (const pkgConfig of inputs.config.packages) {
-      core3.info(`Processing ${pkgConfig.name}`);
-      const commitHash = await client.getLatestVersion(
-        pkgConfig.name,
-        inputs.branch
-      );
-      const hasChanges = commitHash ? await checkForChanges(pkgConfig, commitHash) : true;
-      if (hasChanges) {
-        core3.info(`Changes detected in ${pkgConfig.scope}`);
-        result.push(pkgConfig.scope);
-      }
-    }
+    const changedPackages = await Promise.all(
+      inputs.config.packages.map(async (pkgConfig) => {
+        core3.info(`Processing ${pkgConfig.name}`);
+        const commitHash = await client.getLatestVersion(
+          pkgConfig.name,
+          inputs.branch
+        );
+        const hasChanges = commitHash ? await checkForChanges(pkgConfig, commitHash) : true;
+        if (hasChanges) {
+          core3.info(`Changes detected in ${pkgConfig.scope}`);
+          return pkgConfig.scope;
+        } else {
+          return null;
+        }
+      })
+    );
+    const result = changedPackages.filter((x) => x !== null);
     core3.setOutput("changes", result);
   } catch (error) {
     if (error instanceof Error)

--- a/dist/index.js
+++ b/dist/index.js
@@ -34543,8 +34543,8 @@ var Client = class {
     this.token = token.accessToken;
     return this.token;
   };
-  getLatestVersion = async (component) => {
-    const url = `https://api.mach.cloud/organizations/${this.credentials.organization}/projects/${this.credentials.project}/components/${component}/versions`;
+  getLatestVersion = async (component, branch) => {
+    const url = `https://api.mach.cloud/organizations/${this.credentials.organization}/projects/${this.credentials.project}/components/${component}/latest?branch=${branch}`;
     console.log("Request info from " + url);
     const response = await fetch(url, {
       headers: {
@@ -34556,10 +34556,10 @@ var Client = class {
       throw new Error("Failed to fetch latest version");
     }
     const result = await response.json();
-    if (!result.results.length) {
-      return null;
+    if (result && result.version) {
+      return result.version;
     }
-    return result.results[0].version;
+    return null;
   };
 };
 
@@ -34579,7 +34579,7 @@ async function run() {
     );
     for (const pkgConfig of inputs.config.packages) {
       core3.info(`Processing ${pkgConfig.name}`);
-      const commitHash = await client.getLatestVersion(pkgConfig.name);
+      const commitHash = await client.getLatestVersion(pkgConfig.name, inputs.branch);
       const hasChanges = commitHash ? await checkForChanges(pkgConfig, commitHash) : true;
       if (hasChanges) {
         core3.info(`Changes detected in ${pkgConfig.scope}`);

--- a/node.ts
+++ b/node.ts
@@ -29,9 +29,9 @@ export class Client {
     return this.token;
   };
 
-  public getLatestVersion = async (component: string) => {
+  public getLatestVersion = async (component: string, branch: string) => {
     const response = await fetch(
-      `https://api.mach.cloud/organizations/${this.credentials.organization}/projects/${this.credentials.project}/components/${component}/versions`,
+      `https://api.mach.cloud/organizations/${this.credentials.organization}/projects/${this.credentials.project}/components/${component}/latest?branch=${branch}`,
       {
         headers: {
           Authorization: `Bearer ${await this.getToken()}`,
@@ -39,13 +39,14 @@ export class Client {
       },
     );
     if (!response.ok) {
+      console.log(await response.text());
       throw new Error("Failed to fetch latest version");
     }
     const result = await response.json();
-    if (!result.results.length) {
-      return null;
+    if (result && result.version) {
+      return result.version;
     }
-    return result.results[0].version;
+    return null;
   };
 }
 
@@ -57,5 +58,5 @@ const client = new Client({
   project: "mach-commerce-accelerator",
 });
 
-const version = await client.getLatestVersion("page-resolver");
+const version = await client.getLatestVersion("page-resolver", "main");
 console.log(version);

--- a/src/check.test.ts
+++ b/src/check.test.ts
@@ -1,10 +1,12 @@
-import { it } from "vitest"
-import { gitCheck } from "./check"
-import { PackageConfig } from "./config"
-import { expect } from "vitest"
-
+import { it } from "vitest";
+import { gitCheck } from "./check";
+import { PackageConfig } from "./config";
+import { expect } from "vitest";
 
 it("should pass", async () => {
-  const result = await gitCheck(["src/check.ts", "src/check.test.ts"], "3f0ca33")
-  expect(result).toBe(true)
-})
+  const result = await gitCheck(
+    ["src/check.ts", "src/check.test.ts"],
+    "3f0ca33",
+  );
+  expect(result).toBe(true);
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ type Inputs = {
 export async function run(): Promise<void> {
   try {
     const inputs = readInputs();
+    const result: string[] = [];
 
     const client = new Client({
       clientID: inputs.mccClientID,
@@ -32,27 +33,21 @@ export async function run(): Promise<void> {
         inputs.config.packages.map((pkg) => ` - ${pkg.name}`).join("\n"),
     );
 
-    const changedPackages = await Promise.all(
-      inputs.config.packages.map(async (pkgConfig): Promise<string | null> => {
-        core.info(`Processing ${pkgConfig.name}`);
-        const commitHash = await client.getLatestVersion(
-          pkgConfig.name,
-          inputs.branch,
-        );
-        const hasChanges = commitHash
-          ? await checkForChanges(pkgConfig, commitHash)
-          : true;
+    for (const pkgConfig of inputs.config.packages) {
+      core.info(`Processing ${pkgConfig.name}`);
+      const commitHash = await client.getLatestVersion(
+        pkgConfig.name,
+        inputs.branch,
+      );
+      const hasChanges = commitHash
+        ? await checkForChanges(pkgConfig, commitHash)
+        : true;
 
-        if (hasChanges) {
-          core.info(`Changes detected in ${pkgConfig.scope}`);
-          return pkgConfig.scope;
-        } else {
-          return null;
-        }
-      }),
-    );
-
-    const result = changedPackages.filter((x) => x !== null);
+      if (hasChanges) {
+        core.info(`Changes detected in ${pkgConfig.scope}`);
+        result.push(pkgConfig.scope);
+      }
+    }
 
     core.setOutput("changes", result);
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,7 @@ export async function run(): Promise<void> {
 
 const readInputs = (): Inputs => {
   return {
+    branch: core.getInput("branch"),
     config: parseConfig(core.getInput("config")),
     mccClientID: core.getInput("mcc_client_id"),
     mccClientSecret: core.getInput("mcc_client_secret"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { checkForChanges } from "./check";
 import { Client } from "./mcc";
 
 type Inputs = {
+  branch: string;
   config: Config;
   mccClientID: string;
   mccClientSecret: string;
@@ -34,7 +35,10 @@ export async function run(): Promise<void> {
 
     for (const pkgConfig of inputs.config.packages) {
       core.info(`Processing ${pkgConfig.name}`);
-      const commitHash = await client.getLatestVersion(pkgConfig.name);
+      const commitHash = await client.getLatestVersion(
+        pkgConfig.name,
+        inputs.branch,
+      );
       const hasChanges = commitHash
         ? await checkForChanges(pkgConfig, commitHash)
         : true;

--- a/src/mcc.ts
+++ b/src/mcc.ts
@@ -26,8 +26,8 @@ export class Client {
     return this.token;
   };
 
-  public getLatestVersion = async (component: string) => {
-    const url = `https://api.mach.cloud/organizations/${this.credentials.organization}/projects/${this.credentials.project}/components/${component}/versions`;
+  public getLatestVersion = async (component: string, branch: string) => {
+    const url = `https://api.mach.cloud/organizations/${this.credentials.organization}/projects/${this.credentials.project}/components/${component}/latest?branch=${branch}`;
     console.log("Request info from " + url);
 
     const response = await fetch(url, {
@@ -40,9 +40,9 @@ export class Client {
       throw new Error("Failed to fetch latest version");
     }
     const result = await response.json();
-    if (!result.results.length) {
-      return null;
+    if (result && result.version) {
+      return result.version;
     }
-    return result.results[0].version;
+    return null;
   };
 }


### PR DESCRIPTION
# add branch input

- add (optional) branch input (default=main)
- Add support for branch input, to check latest mcc commit-hash for specific branch
- Use `/latest?branch=<branch>` endpoint to get last commit hash