### PR TITLE
fix: only run git check in case of extra files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34473,7 +34473,7 @@ var exec = __toESM(require_exec(), 1);
 var core2 = __toESM(require_core(), 1);
 import stream from "stream";
 var checkForChanges = async (pkgConfig, commitHash) => {
-  if (await gitCheck(pkgConfig.extraFiles, commitHash)) {
+  if (pkgConfig.extraFiles?.length && await gitCheck(pkgConfig.extraFiles, commitHash)) {
     return true;
   }
   if (await turboCheck(pkgConfig.scope, commitHash)) {

--- a/src/check.ts
+++ b/src/check.ts
@@ -7,7 +7,10 @@ export const checkForChanges = async (
   pkgConfig: PackageConfig,
   commitHash: string,
 ): Promise<boolean> => {
-  if (await gitCheck(pkgConfig.extraFiles, commitHash)) {
+  if (
+    pkgConfig.extraFiles?.length &&
+    (await gitCheck(pkgConfig.extraFiles, commitHash))
+  ) {
     return true;
   }
 


### PR DESCRIPTION
* prevents checking against the whole repo for changes and, consequently, useless builds