### PR TITLE
fix: add TURBO_PRINT_VERSION_DISABLED env variable to have parsable json output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34512,7 +34512,10 @@ var getTurboChangedPackages = async (commitHash) => {
   const command = `pnpm turbo run build --filter="...[${commitHash}]" --dry=json`;
   const options = {
     env: {
+      TURBO_TELEMETRY_DISABLED: "1",
+      // disable printing telemetry message which breaks the json output
       TURBO_PRINT_VERSION_DISABLED: "1",
+      // disable printing turbo version which breaks the json output
       ...process.env
     },
     outStream: nullStream,

--- a/dist/index.js
+++ b/dist/index.js
@@ -34511,6 +34511,10 @@ var getTurboChangedPackages = async (commitHash) => {
   });
   const command = `pnpm turbo run build --filter="...[${commitHash}]" --dry=json`;
   const options = {
+    env: {
+      TURBO_PRINT_VERSION_DISABLED: "1",
+      ...process.env
+    },
     outStream: nullStream,
     failOnStdErr: true
   };

--- a/src/check.ts
+++ b/src/check.ts
@@ -61,7 +61,8 @@ export const getTurboChangedPackages = async (
   const command = `pnpm turbo run build --filter="...[${commitHash}]" --dry=json`;
   const options: exec.ExecOptions = {
     env: {
-      TURBO_PRINT_VERSION_DISABLED: '1',
+      TURBO_TELEMETRY_DISABLED: '1', // disable printing telemetry message which breaks the json output
+      TURBO_PRINT_VERSION_DISABLED: '1', // disable printing turbo version which breaks the json output
       ...process.env
     },
     outStream: nullStream,

--- a/src/check.ts
+++ b/src/check.ts
@@ -60,6 +60,10 @@ export const getTurboChangedPackages = async (
 
   const command = `pnpm turbo run build --filter="...[${commitHash}]" --dry=json`;
   const options: exec.ExecOptions = {
+    env: {
+      TURBO_PRINT_VERSION_DISABLED: '1',
+      ...process.env
+    },
     outStream: nullStream,
     failOnStdErr: true,
   };


### PR DESCRIPTION
Since turbo-repo version 2.10 it prints the version by default when using turbo-cli ([see commit](https://github.com/vercel/turbo/pull/8841/files)).
This makes the output unparsable for us.

By adding a environment variable its possible to disable the version outputting and fixes the problem again.

- `TURBO_PRINT_VERSION_DISABLED: '1'` - disable printing turbo version which breaks the json output
- `TURBO_TELEMETRY_DISABLED: '1'` - disable printing telemetry message which breaks the json output