### PR TITLE
feat: add support for a fallback reference

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,10 @@ inputs:
   mcc_project:
     description: "MACH Composer Project"
     required: true
+  fallback_reference:
+    description: "Fallback git reference to compare against (useful for hotfix branches)"
+    required: false
+    default: ""
 
 # Define your outputs here.
 outputs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,8 @@ export async function run(): Promise<void> {
         inputs.fallbackReference &&
         inputs.fallbackReference != inputs.branch
       ) {
-        // Compare against main
+        // When a fallback reference is given (this can be branch name, a commit or a git tag),
+        // we can check for changes using this reference instead.
         hasChanges = await checkForChanges(pkgConfig, inputs.fallbackReference);
       } else {
         // Consider this a new package


### PR DESCRIPTION
Useful when deploying from a hotfix branch where we want to define a git tag as a fallback reference

We can use this as;

```yaml
- name: Get the last git tag
  if: startsWith(github.ref_name, 'hotfix/')
  id: last_tag
  run: |
    git fetch --tags
    echo "::set-output name=tag::$(git describe --tags --abbrev=0)"

- uses: ./.github/actions/mcc-turbo-changes-action
  id: changes
  with:
    mcc_client_id: ${{ secrets.MCC_CLIENT_ID }}
    mcc_client_secret: ${{ secrets.MCC_CLIENT_SECRET }}
    mcc_organization: organization
    mcc_project: ecommerce
    config: ${{ steps.artifacts.outputs.config }}
    branch: ${{ github.ref_name }}
    fallback_reference: ${{ steps.last_tag.outputs.tag }}
```